### PR TITLE
💡 FEAT: ADD ARIA-LABEL & TITLE FOR SOCIAL ANCHORS ON FOOTER.JS

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -30,19 +30,19 @@ function Footer() {
                       </div>
                     </div>
                     <div className="footer-social">
-                      <a href="#">
+                      <a href="#" aria-label="Visit us on Twitter" title="Twitter (External link)">
                         <i className="fab fa-twitter"></i>
                       </a>
-                      <a href="https://bit.ly/sai4ull">
+                      <a href="https://bit.ly/sai4ull" aria-label="Visit us on Facebook" title="Facebook (External link)">
                         <i className="fab fa-facebook-f"></i>
                       </a>
-                      <a href="#">
+                      <a href="#" aria-label="Visit us on Pinterest" title="Pinterest (External link)">
                         <i className="fab fa-pinterest-p"></i>
                       </a>
-                      <a href="https://www.instagram.com/grabtern.guide/">
+                      <a href="https://www.instagram.com/grabtern.guide/" aria-label="Visit us on Instagram" title="Instagram (External link)">
                         <i className="fab fa-instagram"></i>
                       </a>
-                      <a href="https://www.linkedin.com/company/grabtern/">
+                      <a href="https://www.linkedin.com/company/grabtern/" aria-label="Visit us on Linkedin" title="Linkedin (External link)">
                         <i className="fab fa-linkedin"></i>
                       </a>
                     </div>


### PR DESCRIPTION
## Related Issue
- The issue is about addressing the accessibility issues that can cause by the anchor element (`a`) which is used for social links, because in those links only the image is placed.
- Peoples with vision can identify the social link, but visually impaired persons can't able to understand for the link is to used
- This PR Closes: #182 

## Description of Changes
- This issue can be resolved by adding an explicit `aria-label` along with `title` attribute.
- This change plays an important in terms of accessibility, because as per census more than `25%` population uses screen readers like mechanisms in real life due to their disability
- The `aria-label` can used to point out as `Visit us on {Social}` and the `title` helps to assist that link is external which means it can be another site


## Checklist:

- [x] My code adheres to the established style guidelines of this project.
- [x] I have conducted a self-review of my code.
- [x] I have included comments in areas that may be difficult to understand.
- [x] I have made corresponding updates to the project documentation.
- [x] My changes have not introduced any new warnings.

## Screenshots
- The changes made in accessibility can't be showned visually, it's for disabled people
