### PR TITLE
feat: Sidebar improvements/new navbar for mobile devices

### DIFF
--- a/components/mentorDashboard/sidebar.js
+++ b/components/mentorDashboard/sidebar.js
@@ -218,7 +218,7 @@ const Sidebar = ({ setComponent, component }) => {
                   className="tw-group tw-cursor-pointer hoverList"
                 >
                   <div
-                    className={`tw-flex ${isSidebarOpen ? "tw-justify-start" : "tw-justify-center"} ${component === val.path ? "tw-bg-[#00C9A7] tw-text-primary-100" : ""} tw-p-2 hover:tw-bg-[#00C9A7] group-hover:tw-text-primary-100 tw-transition-all tw-text-xl tw-duration-150 tw-ease-in-out tw-items-center tw-text-gray-900 tw-rounded-lg`}
+                    className={`tw-flex ${isSidebarOpen ? "tw-justify-start" : "tw-justify-center"} ${component === val.path ? "tw-bg-primary-100 tw-text-white" : ""} tw-p-2 hover:tw-bg-[#00C9A7] group-hover:tw-text-primary-100 tw-transition-all tw-text-xl tw-duration-150 tw-ease-in-out tw-items-center tw-text-gray-900 tw-rounded-lg`}
                     onClick={() => setComponent(val.path)}
                   >
                     <span>{val.icon}</span>
@@ -244,7 +244,7 @@ const Sidebar = ({ setComponent, component }) => {
                 className="tw-flex tw-group tw-cursor-pointer hoverList"
               >
                 <div
-                  className={`tw-flex tw-flex-col tw-gap-1 tw-flex-wrap ${component === val.path ? "tw-bg-[#00C9A7] tw-text-primary-100" : ""} tw-p-2 hover:tw-bg-[#00C9A7] group-hover:tw-text-primary-100 tw-transition-all tw-text-xl tw-duration-150 tw-ease-in-out tw-items-center tw-text-gray-900 tw-rounded-lg`}
+                  className={`tw-flex tw-flex-col tw-gap-1 tw-flex-wrap ${component === val.path ? "tw-bg-primary-100 tw-text-white" : ""} tw-p-2 hover:tw-bg-[#00C9A7] group-hover:tw-text-primary-100 tw-transition-all tw-text-xl tw-duration-150 tw-ease-in-out tw-items-center tw-text-gray-900 tw-rounded-lg`}
                   onClick={() => setComponent(val.path)}
                 >
                   <span>{val.icon}</span>
@@ -291,7 +291,7 @@ const Sidebar = ({ setComponent, component }) => {
                     className="tw-flex tw-group tw-cursor-pointer hoverList"
                   >
                     <div
-                      className={`tw-flex tw-flex-wrap ${component === val.path ? "tw-bg-[#00C9A7] tw-text-primary-100" : ""} tw-p-2 hover:tw-bg-[#00C9A7] group-hover:tw-text-primary-100 tw-gap-5 tw-transition-all tw-text-xl tw-duration-150 tw-ease-in-out tw-items-center tw-text-gray-900 tw-rounded-lg`}
+                      className={`tw-flex tw-flex-wrap ${component === val.path ? "tw-bg-primary-100 tw-text-white" : ""} tw-p-2 tw-gap-5 tw-transition-all tw-text-xl tw-duration-150 tw-ease-in-out tw-items-center tw-text-gray-900 tw-rounded-lg`}
                       onClick={() => {
                         setComponent(val.path);
                         setIsMobileSidebarOpen(false);
@@ -312,7 +312,7 @@ const Sidebar = ({ setComponent, component }) => {
                     className="tw-flex tw-group tw-cursor-pointer hoverList"
                   >
                     <div
-                      className={`tw-flex tw-flex-wrap ${component === val.path ? "tw-bg-[#00C9A7] tw-text-primary-100" : ""} tw-p-2 hover:tw-bg-[#00C9A7] group-hover:tw-text-primary-100 tw-gap-5 tw-transition-all tw-text-xl tw-duration-150 tw-ease-in-out tw-items-center tw-text-gray-900 tw-rounded-lg`}
+                      className={`tw-flex tw-flex-wrap ${component === val.path ? "tw-bg-primary-100 tw-text-white" : ""} tw-p-2 tw-gap-5 tw-transition-all tw-text-xl tw-duration-150 tw-ease-in-out tw-items-center tw-text-gray-900 tw-rounded-lg`}
                       onClick={() => {
                         setComponent(val.path);
                         setIsMobileSidebarOpen(false);

--- a/components/mentorDashboard/sidebar.js
+++ b/components/mentorDashboard/sidebar.js
@@ -14,12 +14,14 @@ import { CgProfile } from "react-icons/cg";
 import { IoMdNotificationsOutline } from "react-icons/io";
 import { CgMailOpen } from "react-icons/cg";
 import { BiGift } from "react-icons/bi";
+import { AiOutlineMenu, AiOutlineClose } from "react-icons/ai";
 import Logo from "../../public/assets/img/favicon1.ico";
 import Image from "next/image";
 import styled from "styled-components";
 
 const Sidebar = ({ setComponent, component }) => {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false);
 
   const toggleSidebar = () => {
     console.log("toggle clicked ", isSidebarOpen);
@@ -97,6 +99,30 @@ const Sidebar = ({ setComponent, component }) => {
     },
   ];
 
+  const mobileItem = [
+    {
+      title: "Profile",
+      icon: <CgProfile />,
+      path: "profile",
+    },
+    {
+      title: "Home",
+      icon: <AiOutlineHome />,
+      path: "sessions",
+    },
+    {
+      title: "Bookings",
+      icon: <LuPhoneCall />,
+      path: "bookings",
+    },
+    {
+      title: "Priority DM",
+      icon: <BiMessageRoundedDots />,
+      path: "queries",
+    },
+  ];
+
+
   const BookButton = styled.button`
     margin: 5px;
     :hover {
@@ -148,18 +174,45 @@ const Sidebar = ({ setComponent, component }) => {
             </ul>
           </div>
         </aside>
+      </div>
 
+      <div className="min-[513px]:tw-hidden">
         {/* For mobile devices max-w-512px */}
-
-        {/* <aside>
-          <div className="tw-fixed min-[513px]:tw-hidden tw-flex tw-justify-center tw-items-center tw-bottom-0 tw-left-0 tw-right-0 tw-text-black tw-z-40 tw-bg-gray-200">
+        <aside className="tw-fixed tw-flex tw-justify-around tw-flex-wrap tw-items-center tw-bottom-0 tw-left-0 tw-right-0 tw-text-black tw-z-40 tw-bg-gray-200">
+          <div className="tw-flex tw-justify-center tw-items-center tw-mr-10 max-[400px]:tw-hidden">
             <div className="tw-flex tw-justify-between tw-items-center tw-p-4">
-            <RxRocket className="group-hover:tw-text-primary-100 tw-text-xl" />
+              <RxRocket className="group-hover:tw-text-primary-100 tw-text-xl" />
             </div>
+            <span className="tw-text-gray-600 tw-text-lg">|</span>
           </div>
-        </aside> */}
+          <div className={`tw-gap-8 tw-flex tw-font-medium tw-py-2`}>
+            {mobileItem.map((val, key) => (
+              <HoverListItem
+                key={key}
+                className="tw-flex tw-group tw-cursor-pointer hoverList"
+              >
+                <div
+                  className={`tw-flex tw-flex-wrap ${component === val.path ? "tw-bg-[#00C9A7]" : ""} tw-p-2 hover:tw-bg-[#00C9A7] group-hover:tw-text-primary-100 tw-gap-5 tw-transition-all tw-text-xl tw-duration-150 tw-ease-in-out tw-items-center tw-text-gray-900 tw-rounded-lg`}
+                  onClick={() => setComponent(val.path)}
+                >
+                  <span>{val.icon}</span>
+                  <span className={`tw-ml-3 ${isSidebarOpen ? "tw-block" : "tw-hidden"}`}>{val.title}</span>
+                </div>
+              </HoverListItem>
+            ))}
+          </div>
+          <div className="tw-flex tw-justify-center tw-items-center">
+            {/* a button for expanding the remaining buttons */}
+            <button className="tw-flex tw-justify-center tw-items-center">
+              {
+                isMobileSidebarOpen ? <AiOutlineClose className="tw-text-2xl tw-text-gray-900" onClick={() => setIsMobileSidebarOpen(false)} /> : <AiOutlineMenu className="tw-text-2xl tw-text-gray-900" onClick={() => setIsMobileSidebarOpen(true)} />
+              }
+            </button>
+          </div>
+        </aside>
 
       </div>
+
     </>
   );
 };

--- a/components/mentorDashboard/sidebar.js
+++ b/components/mentorDashboard/sidebar.js
@@ -122,6 +122,61 @@ const Sidebar = ({ setComponent, component }) => {
     },
   ];
 
+  const menuItem1 = [
+    {
+      title: "Profile",
+      icon: <CgProfile />,
+      path: "profile",
+    },
+    {
+      title: "Home",
+      icon: <AiOutlineHome />,
+      path: "sessions",
+    },
+    {
+      title: "Bookings",
+      icon: <LuPhoneCall />,
+      path: "bookings",
+    },
+    {
+      title: "Priority DM",
+      icon: <BiMessageRoundedDots />,
+      path: "queries",
+    },
+    {
+      title: "Calendar",
+      icon: <BiCalendar />,
+      path: "calendar",
+    },
+  ];
+
+  const menuItem2 = [
+    {
+      title: "Services",
+      icon: <PiBookOpenText />,
+      path: "services",
+    },
+    {
+      title: "Payments",
+      icon: <MdPayment />,
+      path: "payments",
+    },
+    {
+      title: "What's New",
+      icon: <IoMdNotificationsOutline />,
+      path: "new",
+    },
+    {
+      title: "Invite & Earn",
+      icon: <CgMailOpen />,
+      path: "referral",
+    },
+    {
+      title: "Rewards",
+      icon: <BiGift />,
+      path: "rewards",
+    },
+  ];
 
   const BookButton = styled.button`
     margin: 5px;
@@ -151,7 +206,7 @@ const Sidebar = ({ setComponent, component }) => {
             <div className={`${isSidebarOpen ? "tw-block" : "tw-hidden"} tw-flex tw-justify-center  tw-items-center`}>
               <Link href="/" className="hover:text-primary-200 tw-font-inter tw-font-bold tw-text-3xl">GrabTern</Link>
             </div>
-            <div className={`tw-group tw-p-2 tw-flex ${isSidebarOpen ? "tw-justify-start tw-gap-4" : "tw-justify-center"} tw-items-center tw-mt-10 tw-rounded-md tw-transition-all tw-duration-150 tw-ease-in-out hover:tw-bg-[#00C9A7] tw-cursor-pointer`}>
+            <div className={`tw-group tw-p-4 tw-flex ${isSidebarOpen ? "tw-justify-start tw-gap-4" : "tw-justify-center"} tw-items-center tw-mt-10 tw-rounded-md tw-transition-all tw-duration-150 tw-ease-in-out tw-bg-white tw-cursor-pointer`}>
               <RxRocket className="group-hover:tw-text-primary-100 tw-text-xl" />
               <span className={`${isSidebarOpen ? "tw-block group-hover:tw-text-primary-100" : "tw-hidden"}`}>Get more bookings</span>
             </div>
@@ -163,7 +218,7 @@ const Sidebar = ({ setComponent, component }) => {
                   className="tw-group tw-cursor-pointer hoverList"
                 >
                   <div
-                    className={`tw-flex ${isSidebarOpen ? "tw-justify-start" : "tw-justify-center"} ${component === val.path ? "tw-bg-[#00C9A7]" : ""} tw-p-2 hover:tw-bg-[#00C9A7] group-hover:tw-text-primary-100 tw-transition-all tw-text-xl tw-duration-150 tw-ease-in-out tw-items-center tw-text-gray-900 tw-rounded-lg`}
+                    className={`tw-flex ${isSidebarOpen ? "tw-justify-start" : "tw-justify-center"} ${component === val.path ? "tw-bg-[#00C9A7] tw-text-primary-100" : ""} tw-p-2 hover:tw-bg-[#00C9A7] group-hover:tw-text-primary-100 tw-transition-all tw-text-xl tw-duration-150 tw-ease-in-out tw-items-center tw-text-gray-900 tw-rounded-lg`}
                     onClick={() => setComponent(val.path)}
                   >
                     <span>{val.icon}</span>
@@ -179,20 +234,17 @@ const Sidebar = ({ setComponent, component }) => {
       <div className="min-[513px]:tw-hidden">
         {/* For mobile devices max-w-512px */}
         <aside className="tw-fixed tw-flex tw-justify-around tw-flex-wrap tw-items-center tw-bottom-0 tw-left-0 tw-right-0 tw-text-black tw-z-40 tw-bg-gray-200">
-          <div className="tw-flex tw-justify-center tw-items-center tw-mr-10 max-[400px]:tw-hidden">
-            <div className="tw-flex tw-justify-between tw-items-center tw-p-4">
-              <RxRocket className="group-hover:tw-text-primary-100 tw-text-xl" />
-            </div>
-            <span className="tw-text-gray-600 tw-text-lg">|</span>
+          <div className="tw-items-center max-[400px]:tw-hidden">
+            <RxRocket className="group-hover:tw-text-primary-100 tw-text-xl" />
           </div>
-          <div className={`tw-gap-8 tw-flex tw-font-medium tw-py-2`}>
+          <div className={`tw-gap-8 tw-flex tw-font-medium tw-p-2`}>
             {mobileItem.map((val, key) => (
               <HoverListItem
                 key={key}
                 className="tw-flex tw-group tw-cursor-pointer hoverList"
               >
                 <div
-                  className={`tw-flex tw-flex-wrap ${component === val.path ? "tw-bg-[#00C9A7]" : ""} tw-p-2 hover:tw-bg-[#00C9A7] group-hover:tw-text-primary-100 tw-gap-5 tw-transition-all tw-text-xl tw-duration-150 tw-ease-in-out tw-items-center tw-text-gray-900 tw-rounded-lg`}
+                  className={`tw-flex tw-flex-wrap ${component === val.path ? "tw-bg-[#00C9A7] tw-text-primary-100" : ""} tw-p-2 hover:tw-bg-[#00C9A7] group-hover:tw-text-primary-100 tw-gap-5 tw-transition-all tw-text-xl tw-duration-150 tw-ease-in-out tw-items-center tw-text-gray-900 tw-rounded-lg`}
                   onClick={() => setComponent(val.path)}
                 >
                   <span>{val.icon}</span>
@@ -205,12 +257,75 @@ const Sidebar = ({ setComponent, component }) => {
             {/* a button for expanding the remaining buttons */}
             <button className="tw-flex tw-justify-center tw-items-center">
               {
-                isMobileSidebarOpen ? <AiOutlineClose className="tw-text-2xl tw-text-gray-900" onClick={() => setIsMobileSidebarOpen(false)} /> : <AiOutlineMenu className="tw-text-2xl tw-text-gray-900" onClick={() => setIsMobileSidebarOpen(true)} />
+                <AiOutlineMenu className="tw-text-2xl tw-text-gray-900" onClick={() => setIsMobileSidebarOpen(true)} />
               }
             </button>
           </div>
         </aside>
 
+        {/* Modal for opening menu */}
+        <div>
+          <div className={`tw-fixed tw-top-0 tw-left-0 tw-right-0 tw-overflow-auto tw-bottom-0 tw-bg-gray-200 tw-z-50 tw-transition-all tw-duration-300 tw-ease-in-out ${isMobileSidebarOpen ? "tw-opacity-100" : "tw-opacity-0 tw-pointer-events-none"}`}>
+            <div className="tw-flex tw-justify-end tw-items-center tw-p-4">
+              <button className="tw-flex tw-justify-center tw-items-center">
+                <AiOutlineClose className="tw-text-4xl tw-text-gray-900" onClick={() => setIsMobileSidebarOpen(false)} />
+              </button>
+            </div>
+            <div className="tw-flex tw-justify-center tw-items-center">
+              <Link href="/" onClick={() => setIsMobileSidebarOpen(false)} className="hover:text-primary-200 tw-font-inter tw-font-bold tw-text-xl">GrabTern</Link>
+            </div>
+            <div className="tw-flex tw-justify-center tw-items-center tw-mt-8">
+              <div className="tw-flex tw-justify-center tw-items-center tw-gap-4 tw-bg-white tw-p-3 tw-rounded-lg">
+                <RxRocket className="group-hover:tw-text-primary-100 tw-text-xl" />
+                <span className="tw-font-semibold">Get more bookings</span>
+              </div>
+            </div>
+            <div className={`tw-flex tw-mt-6 tw-justify-around tw-items-center tw-font-medium tw-p-2`}>
+
+              {/* left part */}
+              <div className="tw-flex tw-flex-col tw-gap-10">
+                {menuItem1.map((val, key) => (
+                  <HoverListItem
+                    key={key}
+                    className="tw-flex tw-group tw-cursor-pointer hoverList"
+                  >
+                    <div
+                      className={`tw-flex tw-flex-wrap ${component === val.path ? "tw-bg-[#00C9A7] tw-text-primary-100" : ""} tw-p-2 hover:tw-bg-[#00C9A7] group-hover:tw-text-primary-100 tw-gap-5 tw-transition-all tw-text-xl tw-duration-150 tw-ease-in-out tw-items-center tw-text-gray-900 tw-rounded-lg`}
+                      onClick={() => {
+                        setComponent(val.path);
+                        setIsMobileSidebarOpen(false);
+                      }}
+                    >
+                      <span className="tw-text-xl">{val.icon}</span>
+                      <span className="tw-text-sm tw-text-center">{val.title}</span>
+                    </div>
+                  </HoverListItem>
+                ))}
+              </div>
+
+              {/* right part */}
+              <div className="tw-flex tw-flex-col tw-gap-10">
+                {menuItem2.map((val, key) => (
+                  <HoverListItem
+                    key={key}
+                    className="tw-flex tw-group tw-cursor-pointer hoverList"
+                  >
+                    <div
+                      className={`tw-flex tw-flex-wrap ${component === val.path ? "tw-bg-[#00C9A7] tw-text-primary-100" : ""} tw-p-2 hover:tw-bg-[#00C9A7] group-hover:tw-text-primary-100 tw-gap-5 tw-transition-all tw-text-xl tw-duration-150 tw-ease-in-out tw-items-center tw-text-gray-900 tw-rounded-lg`}
+                      onClick={() => {
+                        setComponent(val.path);
+                        setIsMobileSidebarOpen(false);
+                      }}
+                    >
+                      <span className="tw-text-xl">{val.icon}</span>
+                      <span className="tw-text-sm tw-text-center">{val.title}</span>
+                    </div>
+                  </HoverListItem>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
 
     </>

--- a/components/mentorDashboard/sidebar.js
+++ b/components/mentorDashboard/sidebar.js
@@ -237,28 +237,29 @@ const Sidebar = ({ setComponent, component }) => {
           <div className="tw-items-center max-[400px]:tw-hidden">
             <RxRocket className="group-hover:tw-text-primary-100 tw-text-xl" />
           </div>
-          <div className={`tw-gap-8 tw-flex tw-font-medium tw-p-2`}>
+          <div className={`tw-gap-4 tw-flex tw-font-medium tw-p-2`}>
             {mobileItem.map((val, key) => (
               <HoverListItem
                 key={key}
                 className="tw-flex tw-group tw-cursor-pointer hoverList"
               >
                 <div
-                  className={`tw-flex tw-flex-wrap ${component === val.path ? "tw-bg-[#00C9A7] tw-text-primary-100" : ""} tw-p-2 hover:tw-bg-[#00C9A7] group-hover:tw-text-primary-100 tw-gap-5 tw-transition-all tw-text-xl tw-duration-150 tw-ease-in-out tw-items-center tw-text-gray-900 tw-rounded-lg`}
+                  className={`tw-flex tw-flex-col tw-gap-1 tw-flex-wrap ${component === val.path ? "tw-bg-[#00C9A7] tw-text-primary-100" : ""} tw-p-2 hover:tw-bg-[#00C9A7] group-hover:tw-text-primary-100 tw-transition-all tw-text-xl tw-duration-150 tw-ease-in-out tw-items-center tw-text-gray-900 tw-rounded-lg`}
                   onClick={() => setComponent(val.path)}
                 >
                   <span>{val.icon}</span>
-                  <span className={`tw-ml-3 ${isSidebarOpen ? "tw-block" : "tw-hidden"}`}>{val.title}</span>
+                  <span className="tw-text-xs max-[350px]:tw-hidden">{val.title}</span>
                 </div>
               </HoverListItem>
             ))}
           </div>
           <div className="tw-flex tw-justify-center tw-items-center">
             {/* a button for expanding the remaining buttons */}
-            <button className="tw-flex tw-justify-center tw-items-center">
+            <button className="tw-flex tw-flex-col tw-gap-1 tw-justify-center tw-items-center">
               {
                 <AiOutlineMenu className="tw-text-2xl tw-text-gray-900" onClick={() => setIsMobileSidebarOpen(true)} />
               }
+              <span className="tw-text-xs max-[350px]:tw-hidden">More</span>
             </button>
           </div>
         </aside>

--- a/components/mentorDashboard/sidebar.js
+++ b/components/mentorDashboard/sidebar.js
@@ -218,7 +218,7 @@ const Sidebar = ({ setComponent, component }) => {
                   className="tw-group tw-cursor-pointer hoverList"
                 >
                   <div
-                    className={`tw-flex ${isSidebarOpen ? "tw-justify-start" : "tw-justify-center"} ${component === val.path ? "tw-bg-primary-100 tw-text-white" : ""} tw-p-2 hover:tw-bg-[#00C9A7] group-hover:tw-text-primary-100 tw-transition-all tw-text-xl tw-duration-150 tw-ease-in-out tw-items-center tw-text-gray-900 tw-rounded-lg`}
+                    className={`tw-flex ${isSidebarOpen ? "tw-justify-start" : "tw-justify-center"} ${component === val.path ? "tw-bg-primary-100 tw-text-white" : ""} tw-p-2 hover:tw-bg-primary-100 group-hover:tw-text-white tw-transition-all tw-text-xl tw-duration-150 tw-ease-in-out tw-items-center tw-text-gray-900 tw-rounded-lg`}
                     onClick={() => setComponent(val.path)}
                   >
                     <span>{val.icon}</span>

--- a/components/mentorDashboard/sidebar.js
+++ b/components/mentorDashboard/sidebar.js
@@ -1,5 +1,5 @@
-import React, { useState } from "react";
-import { Link } from "react-router-dom";
+import React, { Component, useState, useRef } from "react";
+import Link from "next/link";
 import styles from "../../styles/sidebar.module.css";
 
 import { FaTh, FaUserAlt, FaCalendar } from "react-icons/fa";
@@ -18,7 +18,7 @@ import Logo from "../../public/assets/img/favicon1.ico";
 import Image from "next/image";
 import styled from "styled-components";
 
-const Sidebar = ({ setComponent }) => {
+const Sidebar = ({ setComponent, component }) => {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
 
   const toggleSidebar = () => {
@@ -27,7 +27,29 @@ const Sidebar = ({ setComponent }) => {
     setIsSidebarOpen(!isSidebarOpen);
   };
 
-  const menuItem1 = [
+  const refOne = useRef(null);
+
+  //detects if clicked on outside of element for smaller devices
+
+  const handleClickOutside = (event) => {
+    if (refOne.current && !refOne.current.contains(event.target)) {
+      setIsSidebarOpen(false);
+    }
+  };
+
+  React.useEffect(() => {
+    document.addEventListener("click", handleClickOutside, true);
+    return () => {
+      document.removeEventListener("click", handleClickOutside, true);
+    };
+  });
+
+  const menuItem = [
+    {
+      title: "Profile",
+      icon: <CgProfile />,
+      path: "profile",
+    },
     {
       title: "Home",
       icon: <AiOutlineHome />,
@@ -43,9 +65,6 @@ const Sidebar = ({ setComponent }) => {
       icon: <BiMessageRoundedDots />,
       path: "queries",
     },
-  ];
-
-  const menuItem2 = [
     {
       title: "Calendar",
       icon: <BiCalendar />,
@@ -61,14 +80,6 @@ const Sidebar = ({ setComponent }) => {
       icon: <MdPayment />,
       path: "payments",
     },
-    {
-      title: "Profile",
-      icon: <CgProfile />,
-      path: "profile",
-    },
-  ];
-
-  const menuItem3 = [
     {
       title: "What's New",
       icon: <IoMdNotificationsOutline />,
@@ -102,105 +113,52 @@ const Sidebar = ({ setComponent }) => {
 
   return (
     <>
-      <div>
-        <button
-          type="button"
-          className="tw-fixed tw-inline-flex md:tw-hidden sm:tw-block tw-items-center tw-p-2 tw-mt-2 tw-ml-3 tw-z-50 tw-text-sm tw-text-gray-500 tw-rounded-lg tw-sm:hidden tw-hover:bg-gray-100 tw-focus:outline-none tw-focus:ring-2 tw-focus:ring-gray-200"
-          onClick={toggleSidebar}
-        >
-          <span className="tw-sr-only">Open sidebar</span>
-          <svg
-            className="tw-w-6 tw-h-6"
-            aria-hidden="true"
-            fill="currentColor"
-            viewBox="0 0 20 20"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              clip-rule="evenodd"
-              fill-rule="evenodd"
-              d="M2 4.75A.75.75 0 012.75 4h14.5a.75.75 0 010 1.5H2.75A.75.75 0 012 4.75zm0 10.5a.75.75 0 01.75-.75h7.5a.75.75 0 010 1.5h-7.5a.75.75 0 01-.75-.75zM2 10a.75.75 0 01.75-.75h14.5a.75.75 0 010 1.5H2.75A.75.75 0 012 10z"
-            ></path>
-          </svg>
-        </button>
-
+      <div className="max-[512px]:tw-hidden">
+        {/* For laptops and tablets  */}
         <aside
-          className={`tw-fixed tw-top-0 tw-left-0 tw-z-40 tw-w-64 tw-h-screen tw-transform tw-transition-transform tw-bg-base-300 lg:tw-translate-x-0 ${
-            isSidebarOpen ? "tw-translate-x-0" : "tw--translate-x-full"
-          }`}
+          ref={refOne}
+          className={`tw-fixed  max-[768px]:tw-pt-6 tw-top-0 tw-z-40 tw-h-screen tw-ease-in-out tw-duration-300 tw-bg-gray-200 ${isSidebarOpen ? "tw-translate-x-0" : "-tw-translate-x-1"}`}
+          onMouseOver={() => setIsSidebarOpen(true)}
+          onMouseLeave={() => setIsSidebarOpen(false)}
         >
           <div className="tw-h-full tw-px-3 tw-py-4 tw-overflow-y-auto">
-            <div className="tw-flex  tw-items-center">
-              <Image
-                className="tw-px-3 tw-py-4"
-                src={Logo}
-                alt="icon"
-                width={50}
-                height={50}
-              />
-              <div className="tw-font-inter tw-font-bold tw-text-3xl ">
-                GrabTern
-              </div>
+            <div className={`${isSidebarOpen ? "tw-block" : "tw-hidden"} tw-flex tw-justify-center  tw-items-center`}>
+              <Link href="/" className="hover:text-primary-200 tw-font-inter tw-font-bold tw-text-3xl">GrabTern</Link>
             </div>
-            <div className="tw-pt-2 tw-pl-1">
-              <BookButton className="tw-text-center tw-font-inter tw-text-xs tw-font-light tw-bg-white tw-hover:bg-gray-100 tw-text-gray-800 tw-font-semibold tw-py-4 tw-px-10 tw-border tw-border-gray-400 tw-rounded-lg tw-shadow">
-                <div className="tw-flex tw-items-center tw-justify-end">
-                  <RxRocket />
-                  <div className="tw-ml-2">Get more bookings</div>
-                </div>
-              </BookButton>
+            <div className={`tw-group tw-p-2 tw-flex ${isSidebarOpen ? "tw-justify-start tw-gap-4" : "tw-justify-center"} tw-items-center tw-mt-10 tw-rounded-md tw-transition-all tw-duration-150 tw-ease-in-out hover:tw-bg-[#00C9A7] tw-cursor-pointer`}>
+              <RxRocket className="group-hover:tw-text-primary-100 tw-text-xl" />
+              <span className={`${isSidebarOpen ? "tw-block group-hover:tw-text-primary-100" : "tw-hidden"}`}>Get more bookings</span>
             </div>
             <hr className="tw-h-px tw-my-5 tw-bg-gray-300 tw-border-0 tw-dark:bg-gray-700"></hr>
-            <ul className="tw-space-y-2 tw-font-medium tw-py-2">
-              {menuItem1.map((val, key) => (
+            <ul className={`tw-gap-4 tw-flex tw-flex-col tw-font-medium tw-py-2`}>
+              {menuItem.map((val, key) => (
                 <HoverListItem
                   key={key}
                   className="tw-group tw-cursor-pointer hoverList"
                 >
                   <div
-                    className="tw-flex tw-items-center tw-px-2 tw-py-2 tw-text-gray-900 tw-rounded-lg "
+                    className={`tw-flex ${isSidebarOpen ? "tw-justify-start" : "tw-justify-center"} ${component === val.path ? "tw-bg-[#00C9A7]" : ""} tw-p-2 hover:tw-bg-[#00C9A7] group-hover:tw-text-primary-100 tw-transition-all tw-text-xl tw-duration-150 tw-ease-in-out tw-items-center tw-text-gray-900 tw-rounded-lg`}
                     onClick={() => setComponent(val.path)}
                   >
-                    <span className="tw-ml-3">{val.icon}</span>
-                    <span className="tw-ml-3">{val.title}</span>
-                  </div>
-                </HoverListItem>
-              ))}
-            </ul>
-            <ul className="tw-space-y-2 tw-font-medium tw-py-4">
-              {menuItem2.map((val, key) => (
-                <HoverListItem
-                  key={key}
-                  className="tw-group tw-cursor-pointer hoverList"
-                >
-                  <div
-                    className="tw-flex tw-items-center tw-px-2 tw-py-2 tw-text-gray-900 tw-rounded-lg "
-                    onClick={() => setComponent(val.path)}
-                  >
-                    <span className="tw-ml-3">{val.icon}</span>
-                    <span className="tw-ml-3">{val.title}</span>
-                  </div>
-                </HoverListItem>
-              ))}
-            </ul>
-            <ul className="tw-space-y-2 tw-font-medium tw-py-4">
-              {menuItem3.map((val, key) => (
-                <HoverListItem
-                  key={key}
-                  className="tw-group tw-cursor-pointer hoverList"
-                >
-                  <div
-                    className="tw-flex tw-items-center tw-px-2 tw-py-2 tw-text-gray-900 tw-rounded-lg "
-                    onClick={() => setComponent(val.path)}
-                  >
-                    <span className="tw-ml-3">{val.icon}</span>
-                    <span className="tw-ml-3">{val.title}</span>
+                    <span>{val.icon}</span>
+                    <span className={`tw-ml-3 ${isSidebarOpen ? "tw-block" : "tw-hidden"}`}>{val.title}</span>
                   </div>
                 </HoverListItem>
               ))}
             </ul>
           </div>
         </aside>
+
+        {/* For mobile devices max-w-512px */}
+
+        {/* <aside>
+          <div className="tw-fixed min-[513px]:tw-hidden tw-flex tw-justify-center tw-items-center tw-bottom-0 tw-left-0 tw-right-0 tw-text-black tw-z-40 tw-bg-gray-200">
+            <div className="tw-flex tw-justify-between tw-items-center tw-p-4">
+            <RxRocket className="group-hover:tw-text-primary-100 tw-text-xl" />
+            </div>
+          </div>
+        </aside> */}
+
       </div>
     </>
   );

--- a/pages/dashboard/mentor.page.js
+++ b/pages/dashboard/mentor.page.js
@@ -18,7 +18,7 @@ function MentorDashboard() {
     <>
       <div className="">
         {/* <Header navbarBackground={true} /> */}
-        <Sidebar setComponent={updatePath} />
+        <Sidebar setComponent={updatePath} component={component} />
         <div>
           {component == "profile" && <Profile />}
           {component == "calendar" && <Calendar />}


### PR DESCRIPTION
## Closes: #621 


## Description of Changes
- fixed: sidebar
- add: on hover expand effect to the current sidebar for devices with width > 512px
- add: indicator for which page are you on
- add: navbar at bottom for devices with width <= 512px
- add: a menu for expanding more options in mobile devices.

## Checklist:

<!--
Mark the checkboxes to indicate completion. Example:
- [x] My code follows the style guidelines of this project.
-->

- [x] My code adheres to the established style guidelines of this project.
- [x] I have conducted a self-review of my code.
- [x] I have included comments in areas that may be difficult to understand.
- [x] I have made corresponding updates to the project documentation.
- [x] My changes have not introduced any new warnings.


## Screenshots

normal:
![image](https://github.com/anmode/grabtern-frontend/assets/47839626/751f50b4-a3a3-4241-9dc8-cf2550e33095)

on Hover:
![image](https://github.com/anmode/grabtern-frontend/assets/47839626/a67c123a-d47d-43ba-8daa-59ab42130cab)

<img width="960" alt="image" src="https://github.com/anmode/grabtern-frontend/assets/47839626/820a802a-5fe5-4002-86ee-130b412d59a4">

![image](https://github.com/anmode/grabtern-frontend/assets/47839626/9dfc63b5-439d-4899-925a-81aa4d11240f)

![image](https://github.com/anmode/grabtern-frontend/assets/47839626/4028e6d0-ebe3-4499-8074-e4bee4f48749)


@anmode .