### PR TITLE
feat: made social anchors accessible on entire grabtern site 🚀🔥 

### DIFF
--- a/components/layout/Footer.js
+++ b/components/layout/Footer.js
@@ -95,11 +95,46 @@ function Footer() {
           </div>
           {/* social links */}
           <div className="tw-flex tw-gap-1">
-            <IconLink href="#" Icon={RiFacebookFill} variant="secondary" />
-            <IconLink href="#" Icon={RiTwitterFill} variant="secondary" />
-            <IconLink href="#" Icon={RiInstagramFill} variant="secondary" />
-            <IconLink href="#" Icon={RiLinkedinFill} variant="secondary" />
-            <IconLink href="#" Icon={RiGithubFill} variant="secondary" />
+            <IconLink 
+              href="#" 
+              aria-label="Follow us on Facebook"
+              title="Facebook (External Link)"
+              rel="noopener noreferrer" 
+              Icon={RiFacebookFill} 
+              variant="secondary" 
+            />
+            <IconLink 
+                href="#" 
+                aria-label="Follow us on Twitter"
+                title="Twitter (External Link)"
+                rel="noopener noreferrer" 
+                Icon={RiTwitterFill} 
+                variant="secondary" 
+            />
+            <IconLink 
+                href="#" 
+                aria-label="Follow us on Instagram"
+                title="Instagram (External Link)"
+                rel="noopener noreferrer" 
+                Icon={RiInstagramFill} 
+                variant="secondary"
+            />
+            <IconLink 
+                href="#"
+                aria-label="Follow us on Linkedin"
+                title="Linkedin (External Link)"
+                rel="noopener noreferrer" 
+                Icon={RiLinkedinFill} 
+                variant="secondary" 
+            />
+            <IconLink 
+                href="#" 
+                aria-label="Follow us on Github"
+                title="Github (External Link)"
+                rel="noopener noreferrer" 
+                Icon={RiGithubFill} 
+                variant="secondary" 
+            />
           </div>
         </div>
       </div>

--- a/components/layout/Footer.js
+++ b/components/layout/Footer.js
@@ -95,45 +95,45 @@ function Footer() {
           </div>
           {/* social links */}
           <div className="tw-flex tw-gap-1">
-            <IconLink 
-              href="#" 
+            <IconLink
+              href="#"
               aria-label="Follow us on Facebook"
               title="Facebook (External Link)"
-              rel="noopener noreferrer" 
-              Icon={RiFacebookFill} 
-              variant="secondary" 
+              rel="noopener noreferrer"
+              Icon={RiFacebookFill}
+              variant="secondary"
             />
-            <IconLink 
-                href="#" 
-                aria-label="Follow us on Twitter"
-                title="Twitter (External Link)"
-                rel="noopener noreferrer" 
-                Icon={RiTwitterFill} 
-                variant="secondary" 
+            <IconLink
+              href="#"
+              aria-label="Follow us on Twitter"
+              title="Twitter (External Link)"
+              rel="noopener noreferrer"
+              Icon={RiTwitterFill}
+              variant="secondary"
             />
-            <IconLink 
-                href="#" 
-                aria-label="Follow us on Instagram"
-                title="Instagram (External Link)"
-                rel="noopener noreferrer" 
-                Icon={RiInstagramFill} 
-                variant="secondary"
+            <IconLink
+              href="#"
+              aria-label="Follow us on Instagram"
+              title="Instagram (External Link)"
+              rel="noopener noreferrer"
+              Icon={RiInstagramFill}
+              variant="secondary"
             />
-            <IconLink 
-                href="#"
-                aria-label="Follow us on Linkedin"
-                title="Linkedin (External Link)"
-                rel="noopener noreferrer" 
-                Icon={RiLinkedinFill} 
-                variant="secondary" 
+            <IconLink
+              href="#"
+              aria-label="Follow us on Linkedin"
+              title="Linkedin (External Link)"
+              rel="noopener noreferrer"
+              Icon={RiLinkedinFill}
+              variant="secondary"
             />
-            <IconLink 
-                href="#" 
-                aria-label="Follow us on Github"
-                title="Github (External Link)"
-                rel="noopener noreferrer" 
-                Icon={RiGithubFill} 
-                variant="secondary" 
+            <IconLink
+              href="#"
+              aria-label="Follow us on Github"
+              title="Github (External Link)"
+              rel="noopener noreferrer"
+              Icon={RiGithubFill}
+              variant="secondary"
             />
           </div>
         </div>

--- a/components/mentor.js
+++ b/components/mentor.js
@@ -21,11 +21,17 @@ const MentorCard = ({ mentor, link }) => {
         <div className="tw-flex tw-gap-2">
           <IconLink
             href={mentor.social.linkedin}
+            aria-label="Follow me on Linkedin"
+            title="Linkedin (External Link)"
+            rel="noopener noreferrer" 
             Icon={RiLinkedinLine}
             variant="secondary"
           />
           <IconLink
             href={mentor.social.twitter}
+            aria-label="Follow me on Twitter"
+            title="Twitter (External Link)"
+            rel="noopener noreferrer" 
             Icon={RiTwitterLine}
             variant="secondary"
           />

--- a/components/mentor.js
+++ b/components/mentor.js
@@ -23,7 +23,7 @@ const MentorCard = ({ mentor, link }) => {
             href={mentor.social.linkedin}
             aria-label="Follow me on Linkedin"
             title="Linkedin (External Link)"
-            rel="noopener noreferrer" 
+            rel="noopener noreferrer"
             Icon={RiLinkedinLine}
             variant="secondary"
           />
@@ -31,7 +31,7 @@ const MentorCard = ({ mentor, link }) => {
             href={mentor.social.twitter}
             aria-label="Follow me on Twitter"
             title="Twitter (External Link)"
-            rel="noopener noreferrer" 
+            rel="noopener noreferrer"
             Icon={RiTwitterLine}
             variant="secondary"
           />

--- a/components/mentorProfile/components/MentorCard.js
+++ b/components/mentorProfile/components/MentorCard.js
@@ -76,7 +76,7 @@ export default function MentorCard({
               className="tw-flex tw-items-center tw-justify-center tw-bg-[#eceeef] tw-text-[#818a91] tw-w-[30px] tw-h-[30px] tw-rounded-full tw-transition-all tw-duration-[0.2s] tw-ease-linear tw-mr-2 hover:tw-bg-[#ea4c89] hover:tw-text-white"
               aria-label="Mail me on"
               title="Mail (External Link)"
-              rel="noopener noreferrer" 
+              rel="noopener noreferrer"
               href={`mailto:${email}`}
             >
               <MdAlternateEmail className="tw-text-[20px] " />
@@ -85,7 +85,7 @@ export default function MentorCard({
               className="tw-flex tw-items-center tw-justify-center tw-bg-[#eceeef] tw-text-[#818a91] tw-w-[30px] tw-h-[30px] tw-rounded-full tw-transition-all tw-duration-[0.2s] tw-ease-linear tw-mr-2 hover:tw-bg-[#007bb6] hover:tw-text-white"
               aria-label="Follow me on Linkedin"
               title="Linkedin (External Link)"
-              rel="noopener noreferrer" 
+              rel="noopener noreferrer"
               href={`https://www.linkedin.com/in/${socialLinks.linkedin}`}
             >
               <FaLinkedin className="tw-text-[20px] " />
@@ -94,7 +94,7 @@ export default function MentorCard({
               className="tw-flex tw-items-center tw-justify-center tw-bg-[#eceeef] tw-text-[#818a91] tw-w-[30px] tw-h-[30px] tw-rounded-full tw-transition-all tw-duration-[0.2s] tw-ease-linear tw-mr-2 hover:tw-bg-[#00aced] hover:tw-text-white"
               aria-label="Follow me on Twitter"
               title="Twitter (External Link)"
-              rel="noopener noreferrer"               
+              rel="noopener noreferrer"
               href={`https://www.twitter.com/${socialLinks.twitter}`}
             >
               <FaTwitter className="tw-text-[20px] " />

--- a/components/mentorProfile/components/MentorCard.js
+++ b/components/mentorProfile/components/MentorCard.js
@@ -74,18 +74,27 @@ export default function MentorCard({
           <div className=" tw-flex tw-flex-row tw-text-[#4338CA] tw-gap-4  tw-items-center  tw-justify-center tw-m-[5px] tw-px-5 tw-py-0">
             <Link
               className="tw-flex tw-items-center tw-justify-center tw-bg-[#eceeef] tw-text-[#818a91] tw-w-[30px] tw-h-[30px] tw-rounded-full tw-transition-all tw-duration-[0.2s] tw-ease-linear tw-mr-2 hover:tw-bg-[#ea4c89] hover:tw-text-white"
+              aria-label="Mail me on"
+              title="Mail (External Link)"
+              rel="noopener noreferrer" 
               href={`mailto:${email}`}
             >
               <MdAlternateEmail className="tw-text-[20px] " />
             </Link>
             <Link
               className="tw-flex tw-items-center tw-justify-center tw-bg-[#eceeef] tw-text-[#818a91] tw-w-[30px] tw-h-[30px] tw-rounded-full tw-transition-all tw-duration-[0.2s] tw-ease-linear tw-mr-2 hover:tw-bg-[#007bb6] hover:tw-text-white"
+              aria-label="Follow me on Linkedin"
+              title="Linkedin (External Link)"
+              rel="noopener noreferrer" 
               href={`https://www.linkedin.com/in/${socialLinks.linkedin}`}
             >
               <FaLinkedin className="tw-text-[20px] " />
             </Link>
             <Link
               className="tw-flex tw-items-center tw-justify-center tw-bg-[#eceeef] tw-text-[#818a91] tw-w-[30px] tw-h-[30px] tw-rounded-full tw-transition-all tw-duration-[0.2s] tw-ease-linear tw-mr-2 hover:tw-bg-[#00aced] hover:tw-text-white"
+              aria-label="Follow me on Twitter"
+              title="Twitter (External Link)"
+              rel="noopener noreferrer"               
               href={`https://www.twitter.com/${socialLinks.twitter}`}
             >
               <FaTwitter className="tw-text-[20px] " />
@@ -93,6 +102,7 @@ export default function MentorCard({
             {/* Mentor Share Icon Container */}
             <div
               onClick={handleSharePage}
+              aria-label="Share this Mentor's Profile"
               className="tw-flex tw-items-center tw-justify-center tw-bg-[#eceeef] tw-text-[#818a91] tw-w-[30px] tw-h-[30px] tw-rounded-full tw-transition-all tw-duration-[0.2s] tw-ease-linear tw-mr-2 hover:tw-bg-[#4338CA] hover:tw-text-white"
             >
               <FaShareAlt className="tw-text-[20px]  " />


### PR DESCRIPTION
## Related Issue

Closes: #663 

## Description of Changes

- Added `aria-label` attribute for social anchors like github & twitter
- The `aria-label` attribute is important for screen readers because it provides a text label for an object, such as `a` with social icons. When a screen reader encounters the object, the `aria-label` text is read so that the user will know what it is. 
- This is important for people who are blind or have low vision, as they rely on screen readers to access the web.
- Improved `title` attribute's data, because the title attribute is intended to provide additional information to screen reader users.
- And along with that i added `rel` for the anchors which are lacking them to ensure best practices for crawlers
- Because adding the `rel="noopener noreferrer"` attribute can help to protect this website from security vulnerabilities and improve performance. It is a good practice to use this attribute on all external links.
- Overall this PR is intended to make necessary changes to meet best practices for crawlers along with improving accessibility for social anchors

## Checklist:
- [x] My code adheres to the established style guidelines of this project.
- [x] I have conducted a self-review of my code.
- [x] I have included comments in areas that may be difficult to understand.
- [x] I have made corresponding updates to the project documentation.
- [x] My changes have not introduced any new warnings.

## Screenshots
- We can't capture accessibility changes through screenshots as opposed to code changes since accessibility modifications are often imperceptible to the user, as their purpose is to assist disabled individuals.